### PR TITLE
cli: updates runEmulator for Linux

### DIFF
--- a/cli/scripts/webos/run.js
+++ b/cli/scripts/webos/run.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const chalk = require('chalk');
-const execSync = require('child_process').execSync;
+const { exec, execSync } = require('child_process');
 const spawnSync = require('child_process').spawnSync;
 
 function defaultCLIEnv() {
@@ -26,8 +26,12 @@ function runEmulator(ENV) {
       );
       break;
     case 'linux':
-      execSync(
-        `java -jar ${
+      exec(`
+        sh ${
+          ENV
+        }/../../Emulator/v3.0.0/LG_webOS_TV_Emulator.sh
+        &&
+        java -jar ${
           ENV
         }/../../Emulator/v3.0.0/LG_webOS_TV_Emulator_linux_x64.jar -remocon`
       );


### PR DESCRIPTION
In Linux, we need to execute the `LG_webOS_TV_Emulator.sh` file to run the VirtualBox and the `LG_webOS_TV_Emulator_linux_x64.jar` file to run the remote control.

This PR also changes the `execSync` to `exec` child process method because the `LG_webOS_TV_Emulator_linux_x64.jar` blocks the command-line.

Closes #74 