### PR TITLE
Add possibility of having project files in different locations than root, when packaging webos project

### DIFF
--- a/packages/react-tv-cli/scripts/webos/run.js
+++ b/packages/react-tv-cli/scripts/webos/run.js
@@ -74,7 +74,7 @@ function run(root, device) {
     fs.removeSync(`${webosPath}/icon.png`);
     fs.removeSync(`${webosPath}/icon-large.png`);
     ReactTVConfig.files.forEach(file => {
-      fs.removeSync(`${webosPath}/${file}`);
+      fs.removeSync(`${webosPath}/${path.basename(file)}`);
     });
   }
 
@@ -88,10 +88,11 @@ function run(root, device) {
 
     ReactTVConfig.files.forEach(file => {
       const filePath = path.resolve(root, file);
-      const toFile = path.resolve(webosPath, file);
+      const toFile = path.resolve(webosPath, path.basename(file) );
       fs.ensureDirSync(path.dirname(toFile));
       fs.copySync(`${filePath}`, `${toFile}`);
     });
+
   } catch (e) {
     return console.log('FAIL TO MOUNT', e.toString());
   }


### PR DESCRIPTION
Add possibility of copying subdirectories into our project

ex [package.json]:
"react-tv": {
    "files": [
      "./public/index.html",
      "./dist/bundle.js",
      "./dist/assets/"
    ]
  }

./public/index.html file will be copied to [webos_project_root]/index.html
./dist/bundle.js file will be copied to [webos_project_root]/bundle.js
./dist/assets/ dir and it's content will be copied to [webos_project_root]/assets

note 1) in this change, .npmignore was not implemented

note 2) If you add a directory that stand on the root, it will not work. ex:

"react-tv": {
    "files": [
      "./public/index.html",
      "./dist/bundle.js",
      "./dist/assets/",
      "./videos/"
    ]
  }

This was not implemented cause may cause corruption of our default webos_project files, like appinfo.json or even the [].ipk file itself. Problem it could be implemented when the .npmignore.

<!--

Before submitting a pull request, please make sure the following is done:

1. Fork [the repository](https://github.com/raphamorim/react-tv) and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. Format your code with [format](https://github.com/prettier/prettier) (just run `yarn prettier`).
4. Ensure the test suite passes and your code lints (`yarn test`).

-->
