### PR TITLE
Fix/#135 find dom node not working

### DIFF
--- a/examples/navigation/package.json
+++ b/examples/navigation/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "react": "^16.2.0",
-    "react-tv": "^0.4.2",
+    "react-tv": "^0.4.3",
     "react-tv-cli": "^0.4.2",
     "react-tv-navigation": "^0.4.3"
   },

--- a/examples/navigation/package.json
+++ b/examples/navigation/package.json
@@ -22,7 +22,7 @@
     "react": "^16.2.0",
     "react-tv": "^0.4.3",
     "react-tv-cli": "^0.4.2",
-    "react-tv-navigation": "^0.4.3"
+    "react-tv-navigation": "^0.4.2"
   },
   "devDependencies": {
     "babel-core": "^6.4.5",

--- a/packages/react-tv/package.json
+++ b/packages/react-tv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tv",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "React renderer for low memory applications",
   "main": "index.js",
   "files": [

--- a/packages/react-tv/renderer/ReactTVFiberEntry.js
+++ b/packages/react-tv/renderer/ReactTVFiberEntry.js
@@ -21,7 +21,6 @@ import type {
 import ReactTVFiberComponent from './ReactTVFiberComponent';
 import ReactFiberReconciler from 'react-reconciler';
 import {getChildNamespace} from './shared/DOMNamespaces';
-import ReactInstanceMap from './shared/ReactInstanceMap';
 
 import * as ReactDOMComponentTree from './ReactTVComponentTree';
 
@@ -288,10 +287,7 @@ const ReactTVRenderer = {
       return (componentOrElement: any);
     }
 
-    const inst = ReactInstanceMap.get(componentOrElement);
-    if (inst) {
-      return ReactTVFiberRenderer.findHostInstance(inst);
-    }
+    return ReactTVFiberRenderer.findHostInstance(componentOrElement);
   },
   unmountComponentAtNode(container: any) {
     const containerKey =


### PR DESCRIPTION
Until now ReactTVFiberRenderer.findHostInstance received a fiberNode instance through the return of ReactInstanceMap, but it's actually looking to get a component and use its own "get" function to get the fiberNode from the component. It was then failing for trying to get the fiberNode from a fiberNode. 

Fix #135 Fix #134