### PR TITLE
Add fs.readdir to avoid crash when SDK path contains empty spaces

### DIFF
--- a/packages/react-tv-cli/scripts/webos/run.js
+++ b/packages/react-tv-cli/scripts/webos/run.js
@@ -33,7 +33,7 @@ function runEmulator(ENV) {
 }
 
 function run(root, device) {
-  let webOS_TV_SDK_ENV = process.env.WEBOS_CLI_TV || false;
+  let webOS_TV_SDK_ENV = fs.readdir(process.env.WEBOS_CLI_TV) || false;
   let optDevice = '';
 
   if (!webOS_TV_SDK_ENV) {


### PR DESCRIPTION
As response to this issue #154 

I added fs.readdir to avoid empty space cause a wrong path reader. I have limited test environment once I'm on OSx and not on Ubuntu as reported. 

It must solve issue, but before merge, I recommend to test in a ubuntu test environment. 